### PR TITLE
feat: add special commands with # prefix routing

### DIFF
--- a/e2e/special.spec.ts
+++ b/e2e/special.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Special Commands", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("# alone shows all special commands", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#");
+    await expect(
+      page.locator(".result-item", { hasText: "cowork" })
+    ).toBeVisible();
+  });
+
+  test("#cowork shows matching result with Special badge", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#cowork");
+    await expect(
+      page.locator(".result-item", { hasText: "cowork" })
+    ).toBeVisible();
+    await expect(
+      page.locator(".result-item .result-badge", { hasText: "Special" })
+    ).toBeVisible();
+  });
+
+  test("#cowork shows description", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#cowork");
+    await expect(
+      page.locator(".result-item .result-desc", {
+        hasText: "Open kitty in ~/cowork and run cc",
+      })
+    ).toBeVisible();
+  });
+
+  test("#nonexistent shows no results", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#nonexistent");
+    await page.waitForTimeout(200);
+    const empty = page.locator(".result-item.empty");
+    await expect(empty).toBeVisible();
+    await expect(empty).toHaveText("No results");
+  });
+
+  test("partial match #cow filters correctly", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#cow");
+    await expect(
+      page.locator(".result-item", { hasText: "cowork" })
+    ).toBeVisible();
+  });
+
+  test("Enter on special command triggers execute_action", async ({ page }) => {
+    const input = page.locator(".search-input");
+    await input.fill("#cowork");
+    await expect(
+      page.locator(".result-item", { hasText: "cowork" })
+    ).toBeVisible();
+
+    const logs: string[] = [];
+    page.on("console", (msg) => logs.push(msg.text()));
+
+    await input.press("Enter");
+    await page.waitForTimeout(200);
+    expect(logs.some((l) => l.includes("execute_action"))).toBe(true);
+  });
+});

--- a/src-tauri/src/actions/handlers.rs
+++ b/src-tauri/src/actions/handlers.rs
@@ -7,7 +7,16 @@ use crate::router::SearchResult;
 pub fn is_valid_category(category: &str) -> bool {
     matches!(
         category,
-        "onepass" | "file" | "vector" | "app" | "history" | "ssh" | "math" | "action" | "info"
+        "onepass"
+            | "file"
+            | "vector"
+            | "app"
+            | "history"
+            | "ssh"
+            | "math"
+            | "action"
+            | "info"
+            | "special"
     )
 }
 
@@ -19,7 +28,7 @@ pub fn handle_action(
     match result.category.as_str() {
         "onepass" => handle_onepass(result, modifier, app),
         "file" | "vector" => handle_file(result, modifier, app),
-        "app" | "history" => handle_launch(result, app),
+        "app" | "history" | "special" => handle_launch(result, app),
         "ssh" => handle_ssh(result, modifier),
         "math" => handle_math(result, modifier),
         "action" => Ok(()), // Defensive no-op: frontend dispatches via run_setting
@@ -170,6 +179,7 @@ mod tests {
     fn all_known_categories_are_valid() {
         for cat in &[
             "onepass", "file", "vector", "app", "history", "ssh", "math", "action", "info",
+            "special",
         ] {
             assert!(is_valid_category(cat), "{cat} should be valid");
         }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,5 +6,6 @@ pub mod history;
 pub mod math;
 pub mod onepass;
 pub mod settings;
+pub mod special;
 pub mod ssh;
 pub mod vectors;

--- a/src-tauri/src/commands/special.rs
+++ b/src-tauri/src/commands/special.rs
@@ -1,0 +1,111 @@
+use crate::router::SearchResult;
+
+struct SpecialCommand {
+    name: &'static str,
+    description: &'static str,
+    icon: &'static str,
+    exec_command: &'static str,
+}
+
+const COMMANDS: &[SpecialCommand] = &[SpecialCommand {
+    name: "cowork",
+    description: "Open kitty in ~/cowork and run cc",
+    icon: "",
+    exec_command: "kitty sh -c 'cd ~/cowork && cc'",
+}];
+
+pub fn search_special(query: &str) -> Result<Vec<SearchResult>, String> {
+    let q = query.to_lowercase();
+    Ok(COMMANDS
+        .iter()
+        .filter(|cmd| q.is_empty() || cmd.name.to_lowercase().contains(&q))
+        .map(|cmd| SearchResult {
+            id: format!("special-{}", cmd.name),
+            name: cmd.name.to_string(),
+            description: cmd.description.to_string(),
+            icon: cmd.icon.to_string(),
+            category: "special".into(),
+            exec: cmd.exec_command.to_string(),
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_returns_all() {
+        let results = search_special("").unwrap();
+        assert_eq!(results.len(), COMMANDS.len());
+    }
+
+    #[test]
+    fn match_by_name() {
+        let results = search_special("cowork").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "cowork");
+        assert_eq!(results[0].category, "special");
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let results = search_special("COWORK").unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn partial_match() {
+        let results = search_special("cow").unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn no_match() {
+        let results = search_special("nonexistent").unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn result_has_exec_command() {
+        let results = search_special("cowork").unwrap();
+        assert!(results[0].exec.contains("kitty"));
+        assert!(results[0].exec.contains("cowork"));
+    }
+
+    #[test]
+    fn result_id_has_prefix() {
+        let results = search_special("cowork").unwrap();
+        assert!(results[0].id.starts_with("special-"));
+    }
+
+    #[test]
+    fn names_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for cmd in COMMANDS {
+            assert!(seen.insert(cmd.name), "duplicate name: {}", cmd.name);
+        }
+    }
+
+    #[test]
+    fn fields_are_non_empty() {
+        for cmd in COMMANDS {
+            assert!(!cmd.name.is_empty(), "name must not be empty");
+            assert!(
+                !cmd.exec_command.is_empty(),
+                "exec_command must not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn trimmed_query_matches() {
+        // Router trims whitespace before calling search_special;
+        // verify a pre-trimmed query with spaces still works.
+        let results = search_special(" cowork ").unwrap();
+        assert!(
+            results.is_empty(),
+            "leading/trailing spaces should not match since router trims before calling"
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,6 +166,7 @@ function App() {
       chat: "Chat",
       info: "Info",
       action: "Action",
+      special: "Special",
     };
     return labels[cat] || cat;
   };

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -38,6 +38,21 @@ function mockSearch(args: Record<string, unknown>): SearchResult[] {
     ];
   }
 
+  if (query.startsWith("#")) {
+    const q = query.slice(1).trim().toLowerCase();
+    const specials = [
+      {
+        id: "special-cowork",
+        name: "cowork",
+        description: "Open kitty in ~/cowork and run cc",
+        icon: "",
+        category: "special" as const,
+        exec: "kitty sh -c 'cd ~/cowork && cc'",
+      },
+    ];
+    return specials.filter((s) => !q || s.name.includes(q));
+  }
+
   if (query.startsWith("?")) {
     const q = query.slice(1).trim();
     if (!q) {


### PR DESCRIPTION
## Summary

- Add `#`-prefixed special commands provider to Burrow
- First command: `cowork` — opens kitty in `~/cowork` and runs `cc`
- Follows existing provider pattern: `special.rs` module, router dispatch, action handler, mock, e2e tests

## Changes

- **New** `src-tauri/src/commands/special.rs` — `SpecialCommand` struct, static `COMMANDS` registry, `search_special()` with case-insensitive filtering, 10 unit tests
- **`src-tauri/src/router.rs`** — `Special` variant in `RouteKind`, `#` prefix routing in `classify_query` and `search`, 2 new tests
- **`src-tauri/src/actions/handlers.rs`** — `"special"` category validation + dispatch via `handle_launch`
- **`src/App.tsx`** — `"special": "Special"` label
- **`src/mock-tauri.ts`** — `#` prefix mock for e2e testing
- **New** `e2e/special.spec.ts` — 6 Playwright e2e tests

## Test plan

- [x] `cd src-tauri && cargo test` — 248 tests pass (including 12 new special/router tests)
- [x] `npx playwright test` — 69 tests pass (including 6 new special e2e tests)
- [x] Playwright MCP visual verification: `#`, `#cowork`, `#cow`, `#nonexistent`, Enter execution

Somewhere a GPU is overheating so I don't have to think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced special commands feature accessible via "#" prefix in search (e.g., "#cowork").
  * Added the "cowork" special command with description and dedicated "Special" badge in results.
  * Enabled partial matching for special command queries.

* **Tests**
  * Added comprehensive end-to-end test suite for special commands covering search, display, matching, and execution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->