### PR TITLE
feat: show all apps on empty query with auto-scroll

### DIFF
--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -71,7 +71,7 @@ pub fn classify_query(query: &str) -> RouteKind {
 #[tauri::command]
 pub async fn search(query: String, app: tauri::AppHandle) -> Result<Vec<SearchResult>, String> {
     if query.is_empty() {
-        return history::get_frecent(&app).map_err(|e| e.to_string());
+        return apps::get_all_apps_with_frecency(&app);
     }
 
     if query.starts_with('#') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
   const [healthOk, setHealthOk] = useState(true);
   const notificationTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
 
   const doSearch = useCallback(async (q: string) => {
     try {
@@ -83,6 +84,14 @@ function App() {
     const interval = setInterval(checkHealth, 30000);
     return () => clearInterval(interval);
   }, []);
+
+  // Auto-scroll selected item into view on keyboard navigation
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const child = list.children[selectedIndex] as HTMLElement | undefined;
+    child?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
 
   const executeAction = useCallback(async (e: React.KeyboardEvent | null, itemOverride?: SearchResult) => {
     const item = itemOverride ?? results[selectedIndex];
@@ -224,7 +233,7 @@ function App() {
       {chatAnswer && !chatLoading && (
         <div className="chat-answer">{chatAnswer}</div>
       )}
-      <ul className="results-list">
+      <ul ref={listRef} className="results-list">
         {results.map((item, i) => (
           <li
             key={item.id}

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -19,22 +19,24 @@ function mockSearch(args: Record<string, unknown>): SearchResult[] {
 
   if (query === "") {
     return [
-      {
-        id: "firefox",
-        name: "Firefox",
-        description: "Web Browser",
-        icon: "",
-        category: "history",
-        exec: "firefox",
-      },
-      {
-        id: "kitty",
-        name: "Kitty",
-        description: "Terminal Emulator",
-        icon: "",
-        category: "history",
-        exec: "kitty",
-      },
+      // History (frecent) items first
+      { id: "firefox", name: "Firefox", description: "Web Browser", icon: "firefox", category: "history", exec: "firefox" },
+      { id: "kitty", name: "Kitty", description: "Terminal Emulator", icon: "kitty", category: "history", exec: "kitty" },
+      { id: "code", name: "VS Code", description: "Code Editor", icon: "code", category: "history", exec: "code" },
+      // Alphabetical apps without history
+      { id: "blender", name: "Blender", description: "3D Modelling", icon: "blender", category: "app", exec: "blender" },
+      { id: "chromium", name: "Chromium", description: "Web Browser", icon: "chromium", category: "app", exec: "chromium" },
+      { id: "discord", name: "Discord", description: "Chat App", icon: "discord", category: "app", exec: "discord" },
+      { id: "evince", name: "Evince", description: "Document Viewer", icon: "evince", category: "app", exec: "evince" },
+      { id: "nautilus", name: "Files", description: "File Manager", icon: "nautilus", category: "app", exec: "nautilus" },
+      { id: "gimp", name: "GIMP", description: "Image Editor", icon: "gimp", category: "app", exec: "gimp" },
+      { id: "inkscape", name: "Inkscape", description: "Vector Graphics", icon: "inkscape", category: "app", exec: "inkscape" },
+      { id: "libreoffice", name: "LibreOffice", description: "Office Suite", icon: "libreoffice", category: "app", exec: "libreoffice" },
+      { id: "mpv", name: "mpv", description: "Media Player", icon: "mpv", category: "app", exec: "mpv" },
+      { id: "obs", name: "OBS Studio", description: "Screen Recording", icon: "obs", category: "app", exec: "obs" },
+      { id: "steam", name: "Steam", description: "Game Launcher", icon: "steam", category: "app", exec: "steam" },
+      { id: "thunar", name: "Thunar", description: "File Manager", icon: "thunar", category: "app", exec: "thunar" },
+      { id: "vlc", name: "VLC", description: "Media Player", icon: "vlc", category: "app", exec: "vlc" },
     ];
   }
 


### PR DESCRIPTION
## Summary

- Empty query now shows ALL desktop apps instead of just top 10 history items
- Apps sorted by frecency (history first by score desc), then remaining apps alphabetically
- Keyboard navigation auto-scrolls the selected item into view
- History items labeled "Recent", non-history apps labeled "App"

## Changes

- **`apps.rs`** — Added `sort_apps_by_frecency()` pure function, `get_all_apps_with_frecency()`, and `entry_to_result()` helper
- **`history.rs`** — Added `get_frecency_scores()` returning `HashMap<String, f64>` with error logging on corrupt rows
- **`router.rs`** — Empty query now calls `apps::get_all_apps_with_frecency` instead of `history::get_frecent`
- **`App.tsx`** — Added `listRef` and `useEffect` for `scrollIntoView({ block: "nearest" })` on selection change
- **`mock-tauri.ts`** — Expanded empty query mock to 16 items (3 history + 13 app)
- **`launcher.spec.ts`** — 3 new e2e tests for all-apps display, ordering, and auto-scroll

## Test plan

- [x] `cargo test` — 241 tests pass
- [x] `npx playwright test` — 66 tests pass
- [x] Playwright MCP visual verification — all 16 items visible, auto-scroll works
- [x] 7 review agents run (silent-failure-hunter, type-design, code-reviewer, test-analyzer, comment-analyzer, code-simplifier, feature-code-reviewer)

Somewhere a GPU is overheating so I don't have to think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented frecency-based sorting of app results, displaying recently used applications first, followed by alphabetically sorted items.
  * Added automatic scrolling during keyboard navigation to keep the selected result visible on screen.

* **Tests**
  * Added end-to-end tests for launcher UI behavior covering empty query result handling and keyboard navigation functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->