### PR TITLE
fix: prevent shell injection in SSH execution

### DIFF
--- a/src-tauri/src/actions/dry_run.rs
+++ b/src-tauri/src/actions/dry_run.rs
@@ -23,8 +23,7 @@ pub fn exec_shell(cmd: &str) -> Result<(), String> {
 }
 
 pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
-    let truncated: String = text.chars().take(40).collect();
-    eprintln!("[dry-run] copy_to_clipboard: {truncated}");
+    eprintln!("[dry-run] copy_to_clipboard: {}", truncate(text, 40));
     Ok(())
 }
 
@@ -54,6 +53,15 @@ pub fn open_in_vscode(path: &str) -> Result<(), String> {
 
 pub fn launch_app(exec: &str) -> Result<(), String> {
     eprintln!("[dry-run] launch_app: {exec}");
+    Ok(())
+}
+
+pub fn exec_ssh(host: &str, user: Option<&str>) -> Result<(), String> {
+    let target = match user {
+        Some(u) => format!("{}@{}", u, host),
+        None => host.to_string(),
+    };
+    eprintln!("[dry-run] exec_ssh: {target}");
     Ok(())
 }
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -11,20 +11,18 @@ fn match_files_in_dirs(dirs: &[PathBuf], query: &str, limit: usize) -> Vec<Searc
                 let name = entry.file_name().to_string_lossy().to_string();
                 if name.to_lowercase().contains(&query_lower) {
                     let path = entry.path();
-                    let open_cmd = format!(
-                        "xdg-open '{}'",
-                        path.display().to_string().replace('\'', "'\\''")
-                    );
                     results.push(SearchResult {
                         id: path.display().to_string(),
-                        name: name.clone(),
+                        name,
                         description: path
                             .parent()
                             .map(|p| p.display().to_string())
                             .unwrap_or_default(),
                         icon: "".into(),
                         category: "file".into(),
-                        exec: open_cmd,
+                        // Security: exec intentionally empty. handle_file uses result.id
+                        // with xdg_open via Command::arg() to prevent shell injection
+                        exec: String::new(),
                     });
                 }
                 if results.len() >= limit {

--- a/src-tauri/src/commands/vectors.rs
+++ b/src-tauri/src/commands/vectors.rs
@@ -82,14 +82,15 @@ fn search_vectors(
                 .file_name()
                 .map(|f| f.to_string_lossy().to_string())
                 .unwrap_or_else(|| path.clone());
-            let open_cmd = format!("xdg-open '{}'", path.replace('\'', "'\\''"));
             SearchResult {
                 id: path.clone(),
                 name,
                 description: format!("{:.0}% — {}", score * 100.0, preview),
                 icon: "".into(),
                 category: "vector".into(),
-                exec: open_cmd,
+                // Security: exec intentionally empty. handle_file uses result.id
+                // with xdg_open via Command::arg() to prevent shell injection
+                exec: String::new(),
             }
         })
         .collect())

--- a/src-tauri/tests/router_integration.rs
+++ b/src-tauri/tests/router_integration.rs
@@ -55,7 +55,8 @@ Host local
     let results = filter_hosts(hosts, "prod");
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].name, "prod");
-    assert!(results[0].exec.contains("kitty ssh"));
+    // exec now contains just the host alias (no shell command for security)
+    assert_eq!(results[0].exec, "prod");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes shell injection vulnerability in SSH execution (closes #16)
- Replaces shell interpolation (`sh -c`) with safe `Command::arg()` calls
- Adds `--` separator to prevent SSH option injection from malicious hostnames
- Cleans up unused shell command construction in file/vector search results

## Changes

| File | Change |
|------|--------|
| `utils.rs` | Add `exec_ssh()` function using safe `Command::arg()` |
| `ssh.rs` | Store host alias in `exec` field instead of shell command |
| `handlers.rs` | Update `handle_ssh()` to use safe `exec_ssh()` |
| `files.rs` | Remove dead shell command construction |
| `vectors.rs` | Remove dead shell command construction |
| `dry_run.rs` | Add `exec_ssh()` stub for testing |

## Test plan

- [x] All 291 unit tests pass
- [x] Malicious hostname tests verify `$(whoami)` and backticks are stored literally
- [x] Integration tests updated to match new `exec` field format

Somewhere a GPU is overheating so I don't have to think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * SSH connections now execute with enhanced safety mechanisms, eliminating unnecessary shell processing for more secure remote access
  * File operations improved with safer command execution methods to prevent potential vulnerabilities
  * System command handling refined throughout the application for improved overall stability and protection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->