### PR TITLE
refactor: replace stringly-typed SearchResult.category with Category enum

### DIFF
--- a/src-tauri/src/actions/mod.rs
+++ b/src-tauri/src/actions/mod.rs
@@ -18,6 +18,7 @@ pub async fn execute_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::router::Category;
 
     #[test]
     fn info_category_is_noop() {
@@ -27,10 +28,10 @@ mod tests {
             name: "Info".into(),
             description: "".into(),
             icon: "".into(),
-            category: "info".into(),
+            category: Category::Info,
             exec: "".into(),
         };
-        assert!(handlers::is_valid_category(&result.category));
+        assert!(handlers::is_valid_category(result.category));
     }
 
     #[test]
@@ -40,9 +41,9 @@ mod tests {
             name: "= 5".into(),
             description: "".into(),
             icon: "".into(),
-            category: "math".into(),
+            category: Category::Math,
             exec: "".into(),
         };
-        assert!(handlers::is_valid_category(&result.category));
+        assert!(handlers::is_valid_category(result.category));
     }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 use std::path::PathBuf;
 
 fn match_files_in_dirs(dirs: &[PathBuf], query: &str, limit: usize) -> Vec<SearchResult> {
@@ -19,7 +19,7 @@ fn match_files_in_dirs(dirs: &[PathBuf], query: &str, limit: usize) -> Vec<Searc
                             .map(|p| p.display().to_string())
                             .unwrap_or_default(),
                         icon: "".into(),
-                        category: "file".into(),
+                        category: Category::File,
                         // Security: exec intentionally empty. handle_file uses result.id
                         // with xdg_open via Command::arg() to prevent shell injection
                         exec: String::new(),
@@ -116,7 +116,7 @@ mod tests {
         let dir = setup_test_dir();
         let dirs = vec![dir.path().to_path_buf()];
         let results = match_files_in_dirs(&dirs, "readme", 10);
-        assert_eq!(results[0].category, "file");
+        assert_eq!(results[0].category, Category::File);
     }
 
     #[test]

--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 use rusqlite::Connection;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -50,7 +50,7 @@ fn query_frecent(conn: &Connection) -> Result<Vec<SearchResult>, rusqlite::Error
                 exec: row.get(2)?,
                 icon: row.get(3)?,
                 description: row.get(4)?,
-                category: "history".into(),
+                category: Category::History,
             })
         })?
         .filter_map(|r| match r {
@@ -221,7 +221,7 @@ mod tests {
         let conn = test_db();
         insert_launch(&conn, "a", "App", "app", "", "").unwrap();
         let results = query_frecent(&conn).unwrap();
-        assert_eq!(results[0].category, "history");
+        assert_eq!(results[0].category, Category::History);
     }
 
     #[test]

--- a/src-tauri/src/commands/math.rs
+++ b/src-tauri/src/commands/math.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 
 /// Returns true if the input looks like it could be a math expression.
 fn looks_like_math(input: &str) -> bool {
@@ -30,7 +30,7 @@ pub fn try_calculate(input: &str) -> Option<SearchResult> {
                 name: format!("= {display}"),
                 description: format!("{trimmed} = {display}"),
                 icon: "".into(),
-                category: "math".into(),
+                category: Category::Math,
                 exec: "".into(),
             })
         }
@@ -46,7 +46,7 @@ mod tests {
     fn basic_addition() {
         let r = try_calculate("1+3").unwrap();
         assert_eq!(r.name, "= 4");
-        assert_eq!(r.category, "math");
+        assert_eq!(r.category, Category::Math);
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod tests {
     fn result_has_correct_fields() {
         let r = try_calculate("1+1").unwrap();
         assert_eq!(r.id, "math-result");
-        assert_eq!(r.category, "math");
+        assert_eq!(r.category, Category::Math);
         assert!(r.exec.is_empty());
         assert!(r.icon.is_empty());
         assert!(r.description.contains("1+1"));

--- a/src-tauri/src/commands/onepass.rs
+++ b/src-tauri/src/commands/onepass.rs
@@ -1,5 +1,5 @@
 use crate::commands::onepass_vault;
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::Mutex;
@@ -438,7 +438,7 @@ pub async fn search_onepass(query: &str) -> Result<Vec<SearchResult>, String> {
             name: "Load 1Password Data".into(),
             description: "Sign in and load all vault items into memory".into(),
             icon: "".into(),
-            category: "onepass".into(),
+            category: Category::Onepass,
             exec: "op-load-vault".into(),
         }])
     }

--- a/src-tauri/src/commands/onepass_vault.rs
+++ b/src-tauri/src/commands/onepass_vault.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 
 #[derive(Zeroize, ZeroizeOnDrop)]
 struct SecretFields {
@@ -169,7 +169,7 @@ pub fn search_to_results(query: &str) -> Vec<SearchResult> {
             name: m.title,
             description: format!("{} · ⏎ type pw · ⇧ copy pw · ^C copy user", m.category),
             icon: m.icon_b64,
-            category: "onepass".into(),
+            category: Category::Onepass,
             exec: format!("op-vault-item:{}", m.id),
         })
         .collect()
@@ -276,7 +276,7 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "op-id-0");
         assert_eq!(results[0].exec, "op-vault-item:id-0");
-        assert_eq!(results[0].category, "onepass");
+        assert_eq!(results[0].category, Category::Onepass);
         clear_vault();
     }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 
 struct SettingDef {
     id: &'static str,
@@ -54,7 +54,7 @@ pub fn search_settings(query: &str) -> Result<Vec<SearchResult>, String> {
             name: s.name.to_string(),
             description: s.description.to_string(),
             icon: "".into(),
-            category: "action".into(),
+            category: Category::Action,
             exec: "".into(),
         })
         .collect();
@@ -109,7 +109,7 @@ mod tests {
     fn results_have_action_category() {
         let results = search_settings("").unwrap();
         for r in &results {
-            assert_eq!(r.category, "action");
+            assert_eq!(r.category, Category::Action);
         }
     }
 

--- a/src-tauri/src/commands/special.rs
+++ b/src-tauri/src/commands/special.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 
 struct SpecialCommand {
     name: &'static str,
@@ -24,7 +24,7 @@ pub fn search_special(query: &str) -> Result<Vec<SearchResult>, String> {
             name: cmd.name.to_string(),
             description: cmd.description.to_string(),
             icon: cmd.icon.to_string(),
-            category: "special".into(),
+            category: Category::Special,
             exec: cmd.exec_command.to_string(),
         })
         .collect())
@@ -45,7 +45,7 @@ mod tests {
         let results = search_special("cowork").unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "cowork");
-        assert_eq!(results[0].category, "special");
+        assert_eq!(results[0].category, Category::Special);
     }
 
     #[test]

--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -1,4 +1,4 @@
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 use std::fs;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -99,7 +99,7 @@ pub fn filter_hosts(hosts: Vec<SshHost>, query: &str) -> Vec<SearchResult> {
                 name: h.name.clone(),
                 description: format!("{}{}", user_prefix, h.hostname),
                 icon: "".into(),
-                category: "ssh".into(),
+                category: Category::Ssh,
                 // Store host alias only; handler uses safe Command args (no shell interpolation)
                 exec: h.name.clone(),
             }
@@ -247,7 +247,7 @@ Host *
     fn result_has_ssh_category() {
         let hosts = parse_ssh_config_content(SAMPLE_CONFIG);
         let results = filter_hosts(hosts, "server1");
-        assert_eq!(results[0].category, "ssh");
+        assert_eq!(results[0].category, Category::Ssh);
     }
 
     #[test]

--- a/src-tauri/src/commands/vectors.rs
+++ b/src-tauri/src/commands/vectors.rs
@@ -1,5 +1,5 @@
 use crate::ollama;
-use crate::router::SearchResult;
+use crate::router::{Category, SearchResult};
 use rusqlite::Connection;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -87,7 +87,7 @@ fn search_vectors(
                 name,
                 description: format!("{:.0}% — {}", score * 100.0, preview),
                 icon: "".into(),
-                category: "vector".into(),
+                category: Category::Vector,
                 // Security: exec intentionally empty. handle_file uses result.id
                 // with xdg_open via Command::arg() to prevent shell injection
                 exec: String::new(),
@@ -104,7 +104,7 @@ pub async fn search_by_content(query: &str, app: &AppHandle) -> Result<Vec<Searc
             name: "Vector search is disabled".into(),
             description: "Enable in ~/.config/burrow/config.toml".into(),
             icon: "".into(),
-            category: "info".into(),
+            category: Category::Info,
             exec: "".into(),
         }]);
     }
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "/home/user/doc.txt");
         assert_eq!(results[0].name, "doc.txt");
-        assert_eq!(results[0].category, "vector");
+        assert_eq!(results[0].category, Category::Vector);
     }
 
     #[test]

--- a/src-tauri/tests/router_integration.rs
+++ b/src-tauri/tests/router_integration.rs
@@ -1,20 +1,20 @@
 use burrow_lib::commands::math::try_calculate;
 use burrow_lib::commands::settings::search_settings;
 use burrow_lib::commands::ssh::{filter_hosts, parse_ssh_config_content};
-use burrow_lib::router::{classify_query, RouteKind};
+use burrow_lib::router::{classify_query, Category, RouteKind};
 
 #[test]
 fn math_expression_returns_result() {
     let result = try_calculate("2+2").unwrap();
     assert_eq!(result.name, "= 4");
-    assert_eq!(result.category, "math");
+    assert_eq!(result.category, Category::Math);
 }
 
 #[test]
 fn settings_prefix_returns_actions() {
     let results = search_settings("reindex").unwrap();
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0].category, "action");
+    assert_eq!(results[0].category, Category::Action);
 }
 
 #[test]
@@ -63,7 +63,7 @@ Host local
 fn all_settings_have_consistent_structure() {
     let results = search_settings("").unwrap();
     for r in &results {
-        assert_eq!(r.category, "action");
+        assert_eq!(r.category, Category::Action);
         assert!(r.exec.is_empty());
         assert!(r.name.starts_with(':'));
         assert!(!r.id.is_empty());


### PR DESCRIPTION
## Summary

- Add `Category` enum with `#[serde(rename_all = "lowercase")]` for frontend-compatible JSON serialization
- Update all command modules to use `Category` variants instead of string literals
- Update `handlers.rs` to match on `Category` enum variants instead of strings
- Update `is_valid_category()` to take `Category` enum; document that `Chat` is handled by frontend
- Add serialization tests to verify JSON roundtrip correctness
- Update all test assertions to compare `Category` enum variants

## Test plan

- [x] All 324 Rust tests pass
- [x] Pre-commit hooks pass (gitleaks, rustfmt, clippy, rust-test)
- [x] Category serialization tests verify JSON format (`"app"`, `"math"`, etc.)

Closes #13

Somewhere a GPU is overheating so I don't have to think.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a textbook type-safety refactoring: systematic, thoroughly tested (324 passing tests including new serialization tests), and maintains backward compatibility through serde rename attributes. The changes are mechanical and exhaustive pattern matching ensures completeness.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src-tauri/src/router.rs | Added `Category` enum with serde lowercase serialization and comprehensive tests |
| src-tauri/src/actions/handlers.rs | Updated to match on `Category` enum variants; added `Chat` to match arms |
| src-tauri/src/commands/apps.rs | Replaced string literals with `Category::App` and `Category::History` |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved category handling system by replacing string-based categorization with strongly-typed enums, enhancing code reliability and consistency across search result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->