### PR TITLE
feat: auto-refresh desktop app cache

### DIFF
--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,12 +1,24 @@
-import { rmSync } from "fs";
+import { rmSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
 
 export default function globalTeardown() {
-  const dataDir = process.env.BURROW_DATA_DIR;
-  if (dataDir && dataDir.startsWith("/tmp/burrow-e2e-")) {
+  const rootDir = process.env.BURROW_E2E_ROOT_DIR;
+  const markerPath = process.env.BURROW_E2E_ROOT_MARKER;
+  const expectedPrefix = `${tmpdir()}/burrow-e2e-`;
+
+  if (rootDir && rootDir.startsWith(expectedPrefix)) {
     try {
-      rmSync(dataDir, { recursive: true, force: true });
+      rmSync(rootDir, { recursive: true, force: true });
     } catch (e) {
-      console.warn(`[global-teardown] failed to clean up ${dataDir}:`, e);
+      console.warn(`[global-teardown] failed to clean up ${rootDir}:`, e);
+    }
+  }
+
+  if (markerPath) {
+    try {
+      unlinkSync(markerPath);
+    } catch {
+      // Ignore missing marker file.
     }
   }
 }

--- a/e2e/launcher.spec.ts
+++ b/e2e/launcher.spec.ts
@@ -1,4 +1,33 @@
 import { test, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const e2eAppDir = process.env.BURROW_E2E_APP_DIR;
+const e2eLateAppDir = process.env.BURROW_E2E_LATE_APP_DIR;
+
+function writeDesktopEntryTo(dir: string | undefined, id: string, name: string, exec = id) {
+  if (!dir) {
+    throw new Error("Desktop fixture directory must be set for launcher tests");
+  }
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${id}.desktop`),
+    [
+      "[Desktop Entry]",
+      "Type=Application",
+      `Name=${name}`,
+      `Exec=${exec}`,
+      "Icon=",
+      "Comment=Launcher test fixture",
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeDesktopEntry(id: string, name: string, exec = id) {
+  writeDesktopEntryTo(e2eAppDir, id, name, exec);
+}
 
 test.describe("Launcher UI", () => {
   test.beforeEach(async ({ page }) => {
@@ -316,6 +345,42 @@ test.describe("Launcher UI", () => {
     await expect(items.first()).toBeVisible({ timeout: 10000 });
     const count = await items.count();
     expect(count).toBeGreaterThan(10);
+  });
+
+  test("new application appears without restarting Burrow", async ({ page }) => {
+    const input = page.locator(".search-input");
+    const appId = "codex-live-refresh-app";
+    const appName = "Codex Live Refresh App";
+
+    await page.bringToFront();
+    await input.fill(appName);
+    await page.waitForTimeout(200);
+    await expect(page.locator(".result-item.empty")).toHaveText("No results");
+
+    writeDesktopEntry(appId, appName);
+    await expect(page.locator(".result-name").first()).toContainText(appName, {
+      timeout: 10000,
+    });
+  });
+
+  test("manual #refresh rescans immediately", async ({ page }) => {
+    const input = page.locator(".search-input");
+    const appId = "codex-manual-refresh-app";
+    const appName = "Codex Manual Refresh App";
+
+    await input.fill("#refresh");
+    await expect(page.locator(".result-item.selected .result-name")).toHaveText(
+      "refresh"
+    );
+
+    writeDesktopEntryTo(e2eLateAppDir, appId, appName);
+    await page.keyboard.press("Enter");
+
+    await expect(page.locator(".notification")).toContainText("Apps refreshed");
+
+    await input.fill(appName);
+    await page.waitForTimeout(200);
+    await expect(page.locator(".result-name").first()).toContainText(appName);
   });
 
   test("empty query shows history items first, then app items", async ({ page }) => {

--- a/e2e/modifier-keys.spec.ts
+++ b/e2e/modifier-keys.spec.ts
@@ -38,7 +38,7 @@ test.describe("Modifier Key Actions", () => {
   // --- Basic Enter (no modifier) ---
 
   test("Enter on app result executes without error", async ({ page }) => {
-    const errors = await searchAndAct(page, "Firefox", "Enter");
+    const errors = await searchAndAct(page, "Fixture App 1", "Enter");
     expect(
       errors.filter((e) => e.includes("Execute action failed")).length,
       "execute_action should not produce console.error"
@@ -48,21 +48,21 @@ test.describe("Modifier Key Actions", () => {
   test("Shift+Enter on app result executes without error", async ({
     page,
   }) => {
-    const errors = await searchAndAct(page, "Firefox", "Shift+Enter");
+    const errors = await searchAndAct(page, "Fixture App 1", "Shift+Enter");
     expect(
       errors.filter((e) => e.includes("Execute action failed")).length
     ).toBe(0);
   });
 
   test("Ctrl+Enter on app result executes without error", async ({ page }) => {
-    const errors = await searchAndAct(page, "Firefox", "Control+Enter");
+    const errors = await searchAndAct(page, "Fixture App 1", "Control+Enter");
     expect(
       errors.filter((e) => e.includes("Execute action failed")).length
     ).toBe(0);
   });
 
   test("Alt+Enter on app result executes without error", async ({ page }) => {
-    const errors = await searchAndAct(page, "Firefox", "Alt+Enter");
+    const errors = await searchAndAct(page, "Fixture App 1", "Alt+Enter");
     expect(
       errors.filter((e) => e.includes("Execute action failed")).length
     ).toBe(0);
@@ -180,7 +180,7 @@ test.describe("Modifier Key Actions", () => {
 
   test("clicking a result executes without error", async ({ page }) => {
     const input = page.locator(".search-input");
-    await input.fill("Firefox");
+    await input.fill("Fixture App 1");
     await page.waitForTimeout(200);
 
     const errors: string[] = [];

--- a/e2e/special.spec.ts
+++ b/e2e/special.spec.ts
@@ -1,4 +1,28 @@
 import { test, expect } from "@playwright/test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const e2eAppDir = process.env.BURROW_E2E_APP_DIR;
+
+function writeDesktopEntry(id: string, name: string, exec = id) {
+  if (!e2eAppDir) {
+    throw new Error("Desktop fixture directory must be set for special command tests");
+  }
+
+  mkdirSync(e2eAppDir, { recursive: true });
+  writeFileSync(
+    join(e2eAppDir, `${id}.desktop`),
+    [
+      "[Desktop Entry]",
+      "Type=Application",
+      `Name=${name}`,
+      `Exec=${exec}`,
+      "Icon=",
+      "Comment=Special mode test fixture",
+      "",
+    ].join("\n"),
+  );
+}
 
 const coworkResult = (page: import("@playwright/test").Page) =>
   page
@@ -215,5 +239,42 @@ test.describe("Secondary Input Mode", () => {
     // Type in secondary mode
     await input.fill("test-topic");
     await expect(input).toHaveValue("test-topic");
+  });
+
+  test("empty Enter exits secondary mode with a fresh app search after cache updates", async ({
+    page,
+  }) => {
+    const input = page.locator(".search-input");
+    const appId = "aaa-secondary-mode-refresh-app";
+    const appName = "AAA Secondary Mode Refresh App";
+    let searchRequestsAfterExit = 0;
+    let countSearchRequests = false;
+
+    page.on("request", (request) => {
+      if (
+        countSearchRequests &&
+        request.method() === "POST" &&
+        request.url().endsWith("/api/search")
+      ) {
+        searchRequestsAfterExit += 1;
+      }
+    });
+
+    await input.fill("#cowork");
+    await expect(coworkResult(page)).toBeVisible();
+
+    await input.press("Enter");
+    await expect(page.locator(".secondary-indicator")).toBeVisible();
+
+    writeDesktopEntry(appId, appName);
+    await page.waitForTimeout(1500);
+
+    countSearchRequests = true;
+    await input.press("Enter");
+
+    await expect(input).not.toHaveClass(/secondary/);
+    await expect(input).toHaveValue("");
+    await expect.poll(() => searchRequestsAfterExit).toBeGreaterThan(0);
+    await expect(page.locator(".result-name", { hasText: appName })).toBeVisible();
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,37 @@
+import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { defineConfig } from "@playwright/test";
 
-const e2eDataDir = `/tmp/burrow-e2e-${process.pid}`;
+const e2eRootMarker = join(tmpdir(), "burrow-e2e-root.txt");
+const existingRootDir = process.env.BURROW_E2E_ROOT_DIR?.trim()
+  || (existsSync(e2eRootMarker) ? readFileSync(e2eRootMarker, "utf8").trim() : "");
+const e2eRootDir = existingRootDir || realpathSync(mkdtempSync(join(tmpdir(), "burrow-e2e-")));
+
+writeFileSync(e2eRootMarker, `${e2eRootDir}\n`);
+
+const e2eDataDir = join(e2eRootDir, "data");
+const e2eXdgHome = join(e2eRootDir, "xdg-home");
+const e2eXdgShared = join(e2eRootDir, "xdg-shared");
+const e2eXdgLate = join(e2eRootDir, "xdg-late");
+const e2eApplicationsDir = join(e2eXdgHome, "applications");
+const e2eLateApplicationsDir = join(e2eXdgLate, "applications");
+const e2eXdgDataDirs = [e2eXdgShared, e2eXdgLate].join(":");
 
 // Make available to global teardown
+process.env.BURROW_E2E_ROOT_DIR = e2eRootDir;
+process.env.BURROW_E2E_ROOT_MARKER = e2eRootMarker;
 process.env.BURROW_DATA_DIR = e2eDataDir;
+process.env.BURROW_E2E_APP_DIR = e2eApplicationsDir;
+process.env.BURROW_E2E_LATE_APP_DIR = e2eLateApplicationsDir;
+process.env.XDG_DATA_HOME = e2eXdgHome;
+process.env.XDG_DATA_DIRS = e2eXdgDataDirs;
 
 export default defineConfig({
   testDir: "./e2e",
   timeout: 15000,
   retries: 0,
+  workers: 1,
   globalTeardown: "./e2e/global-teardown.ts",
   use: {
     baseURL: "http://localhost:1420",
@@ -19,9 +42,18 @@ export default defineConfig({
       command: "cargo run --bin test-server",
       cwd: "./src-tauri",
       port: 3001,
-      reuseExistingServer: true,
+      reuseExistingServer: false,
       timeout: 120000, // First cold build may be slow; subsequent runs are instant
-      env: { ...process.env, BURROW_DRY_RUN: "1", BURROW_DATA_DIR: e2eDataDir },
+      env: {
+        ...process.env,
+        BURROW_E2E_ROOT_DIR: e2eRootDir,
+        BURROW_DRY_RUN: "1",
+        BURROW_DATA_DIR: e2eDataDir,
+        BURROW_E2E_APP_DIR: e2eApplicationsDir,
+        BURROW_E2E_LATE_APP_DIR: e2eLateApplicationsDir,
+        XDG_DATA_HOME: e2eXdgHome,
+        XDG_DATA_DIRS: e2eXdgDataDirs,
+      },
     },
     {
       command: "pnpm dev",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { defineConfig } from "@playwright/test";
 
-const e2eRootMarker = join(tmpdir(), "burrow-e2e-root.txt");
+const e2eRootMarker = process.env.BURROW_E2E_ROOT_MARKER?.trim()
+  || join(tmpdir(), `burrow-e2e-root-${process.pid}.txt`);
 const existingRootDir = process.env.BURROW_E2E_ROOT_DIR?.trim()
   || (existsSync(e2eRootMarker) ? readFileSync(e2eRootMarker, "utf8").trim() : "");
 const e2eRootDir = existingRootDir || realpathSync(mkdtempSync(join(tmpdir(), "burrow-e2e-")));

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "indicatif",
  "libc",
  "mexe",
+ "notify",
  "nucleo",
  "pdf-extract",
  "reqwest 0.13.1",
@@ -1662,6 +1663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2512,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2665,26 @@ dependencies = [
  "bitflags 2.10.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2905,6 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3029,6 +3080,33 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom 8.0.0",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ http-body-util = "0.1.3"
 libc = "0.2.180"
 ctrlc = "3.5.1"
 dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }
+notify = "8.2.0"
 
 [[bin]]
 name = "test-server"

--- a/src-tauri/src/actions/handlers.rs
+++ b/src-tauri/src/actions/handlers.rs
@@ -24,10 +24,10 @@ pub fn is_valid_category(category: Category) -> bool {
 
 /// Resolve user-provided results to trusted, canonical command payloads.
 /// This prevents untrusted clients from injecting arbitrary `exec` values.
-fn resolve_trusted_result(result: &SearchResult) -> Result<SearchResult, String> {
+fn resolve_trusted_result(result: &SearchResult, ctx: &AppContext) -> Result<SearchResult, String> {
     match result.category {
         Category::App | Category::History => {
-            let exec = apps::resolve_app_exec(&result.id)
+            let exec = apps::resolve_app_exec(&result.id, ctx)
                 .ok_or_else(|| format!("Unknown app id for action: {}", result.id))?;
             let mut trusted = result.clone();
             trusted.exec = exec;
@@ -69,7 +69,12 @@ pub fn handle_action(
     secondary_input: Option<&str>,
     ctx: &AppContext,
 ) -> Result<(), String> {
-    let trusted = resolve_trusted_result(result)?;
+    let trusted = resolve_trusted_result(result, ctx)?;
+
+    if trusted.category == Category::Special && trusted.id == "special-refresh" {
+        apps::refresh_app_cache(ctx)?;
+        return Ok(());
+    }
 
     match trusted.category {
         Category::Onepass => handle_onepass(&trusted, modifier, ctx),
@@ -304,6 +309,40 @@ fn extract_user_from_description(description: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::history::DbState;
+    use crate::commands::vectors::VectorDbState;
+    use crate::context::AppContext;
+    use crate::indexer::IndexerState;
+    use crate::output_buffers::OutputBufferState;
+    use rusqlite::Connection;
+    use std::fs;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn in_memory_ctx() -> AppContext {
+        AppContext::new(
+            DbState::new(Connection::open_in_memory().unwrap()),
+            VectorDbState::new(Connection::open_in_memory().unwrap()),
+            IndexerState::new(),
+        )
+    }
+
+    fn ctx_with_apps(apps: Arc<apps::AppIndexState>) -> AppContext {
+        AppContext::from_arcs(
+            Arc::new(DbState::new(Connection::open_in_memory().unwrap())),
+            Arc::new(VectorDbState::new(Connection::open_in_memory().unwrap())),
+            Arc::new(IndexerState::new()),
+            Arc::new(OutputBufferState::new()),
+            apps,
+        )
+    }
+
+    fn write_desktop_file(dir: &std::path::Path, file_name: &str, name: &str, exec: &str) {
+        let content = format!(
+            "[Desktop Entry]\nType=Application\nName={name}\nExec={exec}\nIcon=\nComment=\n"
+        );
+        fs::write(dir.join(file_name), content).expect("should write desktop file");
+    }
 
     #[test]
     fn extract_user_from_description_with_user() {
@@ -371,6 +410,7 @@ mod tests {
 
     #[test]
     fn resolve_trusted_result_rejects_unknown_app_id() {
+        let ctx = in_memory_ctx();
         let forged = SearchResult {
             id: "definitely-not-real".into(),
             name: "Forged".into(),
@@ -382,12 +422,13 @@ mod tests {
             output_mode: None,
             output_format: None,
         };
-        let err = resolve_trusted_result(&forged).unwrap_err();
+        let err = resolve_trusted_result(&forged, &ctx).unwrap_err();
         assert!(err.contains("Unknown app id"));
     }
 
     #[test]
     fn resolve_trusted_result_overrides_special_exec() {
+        let ctx = in_memory_ctx();
         let forged = SearchResult {
             id: "special-cowork".into(),
             name: "cowork".into(),
@@ -402,7 +443,8 @@ mod tests {
             output_mode: None,
             output_format: None,
         };
-        let trusted = resolve_trusted_result(&forged).expect("special command should resolve");
+        let trusted =
+            resolve_trusted_result(&forged, &ctx).expect("special command should resolve");
         assert_ne!(trusted.exec, "rm -rf /");
         assert!(trusted.exec.contains("codex"));
         assert!(trusted.input_spec.is_some());
@@ -410,6 +452,7 @@ mod tests {
 
     #[test]
     fn resolve_trusted_result_derives_onepass_exec_from_id() {
+        let ctx = in_memory_ctx();
         let forged = SearchResult {
             id: "op-abc123".into(),
             name: "1Password".into(),
@@ -424,9 +467,40 @@ mod tests {
             output_mode: None,
             output_format: None,
         };
-        let trusted = resolve_trusted_result(&forged).expect("onepass result should resolve");
+        let trusted = resolve_trusted_result(&forged, &ctx).expect("onepass result should resolve");
         assert_eq!(trusted.exec, "op-vault-item:abc123");
         assert!(trusted.input_spec.is_none());
+    }
+
+    #[test]
+    fn handle_action_refreshes_app_cache_for_special_refresh() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha");
+        let apps = Arc::new(apps::AppIndexState::new_for_test(vec![dir
+            .path()
+            .to_path_buf()]));
+        let ctx = ctx_with_apps(apps.clone());
+
+        write_desktop_file(dir.path(), "t3code.desktop", "t3code", "t3code");
+
+        let result = SearchResult {
+            id: "special-refresh".into(),
+            name: "refresh".into(),
+            description: "Rescan application folders now".into(),
+            icon: "".into(),
+            category: Category::Special,
+            exec: "rm -rf /".into(),
+            input_spec: None,
+            output_mode: None,
+            output_format: None,
+        };
+
+        handle_action(&result, Modifier::None, None, &ctx).expect("refresh action should succeed");
+
+        assert!(
+            apps.search("t3code").iter().any(|item| item.id == "t3code"),
+            "special refresh should update the shared app cache"
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/test_server.rs
+++ b/src-tauri/src/bin/test_server.rs
@@ -6,7 +6,57 @@
 //!
 //! This is used by Playwright e2e tests as the backend, replacing `pnpm tauri dev`.
 
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+fn write_fixture_desktop_entry(
+    dir: &Path,
+    id: &str,
+    name: &str,
+    exec: &str,
+) -> std::io::Result<()> {
+    fs::write(
+        dir.join(format!("{id}.desktop")),
+        format!(
+            "[Desktop Entry]\nType=Application\nName={name}\nExec={exec}\nIcon=\nComment=Playwright fixture\n"
+        ),
+    )
+}
+
+fn prepare_e2e_application_fixtures() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(app_dir) = std::env::var("BURROW_E2E_APP_DIR") else {
+        return Ok(());
+    };
+
+    let app_dir = PathBuf::from(app_dir);
+    fs::create_dir_all(&app_dir)?;
+
+    for entry in fs::read_dir(&app_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("desktop") {
+            fs::remove_file(path)?;
+        }
+    }
+
+    if let Ok(shared_roots) = std::env::var("XDG_DATA_DIRS") {
+        if let Some(shared_root) = shared_roots.split(':').next() {
+            fs::create_dir_all(PathBuf::from(shared_root).join("applications"))?;
+        }
+    }
+
+    for i in 1..=12 {
+        write_fixture_desktop_entry(
+            &app_dir,
+            &format!("fixture-{i}"),
+            &format!("Fixture App {i}"),
+            &format!("fixture-app-{i}"),
+        )?;
+    }
+
+    Ok(())
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,9 +64,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     burrow_lib::logging::init_logging();
     burrow_lib::config::init_config();
-    burrow_lib::commands::apps::init_app_cache();
+    prepare_e2e_application_fixtures()?;
 
     let ctx = Arc::new(burrow_lib::context::AppContext::from_disk()?);
+    if let Err(error) = ctx.start_app_watcher() {
+        tracing::warn!(error = %error, "application watcher unavailable in test-server mode; continuing without auto-refresh");
+    }
 
     let router = burrow_lib::dev_server::build_router(ctx);
 

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -1,13 +1,21 @@
+use crate::context::AppContext;
 use crate::icons;
 use crate::router::{Category, SearchResult};
 use freedesktop_entry_parser::parse_entry;
+use notify::{self, RecommendedWatcher, RecursiveMode, Watcher};
 use nucleo::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo::Matcher;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::OnceLock;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc, Mutex, RwLock,
+};
+use std::time::Duration;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct DesktopEntry {
     id: String,
     name: String,
@@ -17,10 +25,244 @@ struct DesktopEntry {
     no_display: bool,
 }
 
-static APP_CACHE: OnceLock<Vec<DesktopEntry>> = OnceLock::new();
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppCacheStatus {
+    pub revision: u64,
+    pub app_count: usize,
+}
 
-pub fn init_app_cache() {
-    APP_CACHE.get_or_init(load_desktop_entries);
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RefreshAppsResult {
+    pub changed: bool,
+    pub revision: u64,
+    pub app_count: usize,
+}
+
+pub struct AppIndexState {
+    entries: RwLock<Vec<DesktopEntry>>,
+    revision: AtomicU64,
+    watcher_started: AtomicBool,
+    watcher: Mutex<Option<RecommendedWatcher>>,
+    source_dirs: Vec<PathBuf>,
+}
+
+#[derive(Default)]
+struct WatcherRefreshState {
+    scheduled: bool,
+    dirty: bool,
+}
+
+impl Default for AppIndexState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppIndexState {
+    pub fn new() -> Self {
+        Self::new_with_dirs(desktop_dirs())
+    }
+
+    fn new_with_dirs(dirs: Vec<PathBuf>) -> Self {
+        let source_dirs = dedupe_dirs(dirs);
+        let entries = load_desktop_entries_from_dirs(&source_dirs);
+        Self {
+            entries: RwLock::new(entries),
+            revision: AtomicU64::new(1),
+            watcher_started: AtomicBool::new(false),
+            watcher: Mutex::new(None),
+            source_dirs,
+        }
+    }
+
+    fn snapshot(&self) -> Vec<DesktopEntry> {
+        self.entries
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    pub fn status(&self) -> AppCacheStatus {
+        let entries = self
+            .entries
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        AppCacheStatus {
+            revision: self.revision.load(Ordering::SeqCst),
+            app_count: entries.len(),
+        }
+    }
+
+    pub fn refresh(&self) -> Result<RefreshAppsResult, String> {
+        self.refresh_from_dirs(&self.source_dirs)
+    }
+
+    fn refresh_from_dirs(&self, dirs: &[PathBuf]) -> Result<RefreshAppsResult, String> {
+        let next_entries = load_desktop_entries_from_dirs(dirs);
+        let mut entries = self
+            .entries
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *entries == next_entries {
+            return Ok(RefreshAppsResult {
+                changed: false,
+                revision: self.revision.load(Ordering::SeqCst),
+                app_count: entries.len(),
+            });
+        }
+
+        *entries = next_entries;
+        let revision = self.revision.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(RefreshAppsResult {
+            changed: true,
+            revision,
+            app_count: entries.len(),
+        })
+    }
+
+    pub fn search(&self, query: &str) -> Vec<SearchResult> {
+        let entries = self.snapshot();
+        fuzzy_search(&entries, query)
+    }
+
+    pub fn resolve_exec(&self, id: &str) -> Option<String> {
+        let entries = self
+            .entries
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        entries
+            .iter()
+            .find(|entry| entry.id == id)
+            .map(|entry| entry.exec.clone())
+    }
+
+    pub fn start_watcher(self: &Arc<Self>) -> Result<(), String> {
+        if self
+            .watcher_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Ok(());
+        }
+
+        let index = Arc::clone(self);
+        let refresh_state = Arc::new(Mutex::new(WatcherRefreshState::default()));
+        let refresh_state_for_callback = Arc::clone(&refresh_state);
+
+        let mut watcher = match notify::recommended_watcher(
+            move |result: notify::Result<notify::Event>| {
+                let event = match result {
+                    Ok(event) => event,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "application directory watch event failed");
+                        return;
+                    }
+                };
+
+                if !event.paths.iter().any(|path| is_relevant_app_fs_path(path)) {
+                    return;
+                }
+
+                let should_spawn = {
+                    let mut state = refresh_state_for_callback
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    state.dirty = true;
+                    if state.scheduled {
+                        false
+                    } else {
+                        state.scheduled = true;
+                        true
+                    }
+                };
+
+                if !should_spawn {
+                    return;
+                }
+
+                let index = Arc::clone(&index);
+                let refresh_state = Arc::clone(&refresh_state_for_callback);
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(Duration::from_millis(300));
+
+                    {
+                        let mut state = refresh_state
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        state.dirty = false;
+                    }
+
+                    if let Err(error) = index.refresh() {
+                        tracing::warn!(error = %error, "application cache refresh failed after watch event");
+                    }
+
+                    let should_continue = {
+                        let mut state = refresh_state
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if state.dirty {
+                            state.dirty = false;
+                            true
+                        } else {
+                            state.scheduled = false;
+                            false
+                        }
+                    };
+
+                    if !should_continue {
+                        break;
+                    }
+                });
+            },
+        ) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                self.watcher_started.store(false, Ordering::SeqCst);
+                return Err(error.to_string());
+            }
+        };
+
+        let mut watched = 0usize;
+        for dir in &self.source_dirs {
+            if !dir.exists() {
+                tracing::info!(path = %dir.display(), "skipping missing application directory");
+                continue;
+            }
+            match watcher.watch(dir, RecursiveMode::NonRecursive) {
+                Ok(()) => watched += 1,
+                Err(error) => {
+                    tracing::warn!(path = %dir.display(), error = %error, "failed to watch application directory");
+                }
+            }
+        }
+
+        if watched == 0 {
+            self.watcher_started.store(false, Ordering::SeqCst);
+            return Err("no application directories could be watched".to_string());
+        }
+
+        tracing::info!(
+            watched_dirs = watched,
+            "application directory watcher started"
+        );
+
+        *self
+            .watcher
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(watcher);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(dirs: Vec<PathBuf>) -> Self {
+        Self::new_with_dirs(dirs)
+    }
+
+    #[cfg(test)]
+    fn refresh_from_dirs_for_test(&self) -> RefreshAppsResult {
+        self.refresh()
+            .expect("refresh_from_dirs_for_test should not fail")
+    }
 }
 
 fn desktop_dirs() -> Vec<PathBuf> {
@@ -53,10 +295,15 @@ fn desktop_dirs() -> Vec<PathBuf> {
     dirs
 }
 
+#[cfg(test)]
 fn load_desktop_entries() -> Vec<DesktopEntry> {
+    load_desktop_entries_from_dirs(&desktop_dirs())
+}
+
+fn load_desktop_entries_from_dirs(dirs: &[PathBuf]) -> Vec<DesktopEntry> {
     let mut entries = Vec::new();
     let mut seen_ids = std::collections::HashSet::new();
-    for dir in desktop_dirs() {
+    for dir in dirs {
         let pattern = dir.join("*.desktop");
         if let Ok(paths) = glob::glob(pattern.to_str().unwrap_or("")) {
             for path in paths.flatten() {
@@ -68,7 +315,22 @@ fn load_desktop_entries() -> Vec<DesktopEntry> {
             }
         }
     }
+    entries.sort_by(|a, b| a.id.cmp(&b.id));
     entries
+}
+
+fn dedupe_dirs(dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = std::collections::HashSet::new();
+    dirs.into_iter()
+        .filter(|dir| seen.insert(dir.clone()))
+        .collect()
+}
+
+fn is_relevant_app_fs_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("desktop"))
+        .unwrap_or(false)
 }
 
 fn parse_desktop_file(path: &PathBuf) -> Option<DesktopEntry> {
@@ -226,10 +488,8 @@ fn sort_apps_by_frecency(
 
 /// Returns all apps sorted by frecency (history first, then alphabetical).
 /// Uses AppContext (Tauri-free).
-pub fn get_all_apps_with_frecency(
-    ctx: &crate::context::AppContext,
-) -> Result<Vec<SearchResult>, String> {
-    let apps = APP_CACHE.get().ok_or("App cache not initialized")?;
+pub fn get_all_apps_with_frecency(ctx: &AppContext) -> Result<Vec<SearchResult>, String> {
+    let apps = ctx.apps.snapshot();
     let scores = match super::history::get_frecency_scores(ctx) {
         Ok(s) => s,
         Err(e) => {
@@ -237,21 +497,34 @@ pub fn get_all_apps_with_frecency(
             std::collections::HashMap::new()
         }
     };
-    Ok(sort_apps_by_frecency(apps, &scores))
+    Ok(sort_apps_by_frecency(&apps, &scores))
 }
 
-pub fn search_apps(query: &str) -> Result<Vec<SearchResult>, String> {
-    let apps = APP_CACHE.get().ok_or("App cache not initialized")?;
-    Ok(fuzzy_search(apps, query))
+pub fn search_apps(query: &str, ctx: &AppContext) -> Result<Vec<SearchResult>, String> {
+    Ok(ctx.apps.search(query))
 }
 
 /// Resolve a canonical app exec command by app ID from cache.
-pub fn resolve_app_exec(id: &str) -> Option<String> {
-    APP_CACHE
-        .get()?
-        .iter()
-        .find(|entry| entry.id == id)
-        .map(|entry| entry.exec.clone())
+pub fn resolve_app_exec(id: &str, ctx: &AppContext) -> Option<String> {
+    ctx.apps.resolve_exec(id)
+}
+
+pub fn refresh_app_cache(ctx: &AppContext) -> Result<RefreshAppsResult, String> {
+    ctx.apps.refresh()
+}
+
+#[tauri::command]
+pub fn app_cache_status_cmd(app: tauri::AppHandle) -> Result<AppCacheStatus, String> {
+    use tauri::Manager;
+    let ctx = app.state::<AppContext>();
+    Ok(ctx.apps.status())
+}
+
+#[tauri::command]
+pub fn refresh_app_cache_cmd(app: tauri::AppHandle) -> Result<RefreshAppsResult, String> {
+    use tauri::Manager;
+    let ctx = app.state::<AppContext>();
+    refresh_app_cache(&ctx)
 }
 
 fn parse_exec_command(exec: &str) -> Result<Vec<String>, String> {
@@ -279,6 +552,10 @@ pub fn launch_app(exec: String) -> Result<(), String> {
 mod tests {
     use super::*;
     use base64::Engine;
+    use std::fs;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tempfile::tempdir;
 
     fn make_entry(id: &str, name: &str, exec: &str) -> DesktopEntry {
         DesktopEntry {
@@ -661,5 +938,195 @@ mod tests {
                 r.id
             );
         }
+    }
+
+    fn write_desktop_file(dir: &std::path::Path, file_name: &str, name: &str, exec: &str) {
+        let content = format!(
+            "[Desktop Entry]\nType=Application\nName={name}\nExec={exec}\nIcon=\nComment=\n"
+        );
+        fs::write(dir.join(file_name), content).expect("should write desktop file");
+    }
+
+    #[test]
+    fn refresh_adds_new_desktop_entry() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha");
+        let index = AppIndexState::new_for_test(vec![dir.path().to_path_buf()]);
+
+        write_desktop_file(dir.path(), "t3code.desktop", "t3code", "t3code");
+        let refreshed = index.refresh_from_dirs_for_test();
+
+        assert!(refreshed.changed);
+        assert_eq!(refreshed.revision, 2);
+        let results = index.search("t3code");
+        assert!(results.iter().any(|result| result.id == "t3code"));
+    }
+
+    #[test]
+    fn refresh_removes_deleted_desktop_entry() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha");
+        let index = AppIndexState::new_for_test(vec![dir.path().to_path_buf()]);
+
+        fs::remove_file(dir.path().join("alpha.desktop")).unwrap();
+        let refreshed = index.refresh_from_dirs_for_test();
+
+        assert!(refreshed.changed);
+        assert!(index.search("alpha").is_empty());
+    }
+
+    #[test]
+    fn refresh_updates_exec_for_existing_id() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha --old");
+        let index = AppIndexState::new_for_test(vec![dir.path().to_path_buf()]);
+
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha --new");
+        let refreshed = index.refresh_from_dirs_for_test();
+
+        assert!(refreshed.changed);
+        assert_eq!(index.resolve_exec("alpha").as_deref(), Some("alpha --new"));
+    }
+
+    #[test]
+    fn refresh_no_change_keeps_revision() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha");
+        let index = AppIndexState::new_for_test(vec![dir.path().to_path_buf()]);
+
+        let status_before = index.status();
+        let refreshed = index.refresh_from_dirs_for_test();
+        let status_after = index.status();
+
+        assert!(!refreshed.changed);
+        assert_eq!(refreshed.revision, status_before.revision);
+        assert_eq!(status_after.revision, status_before.revision);
+    }
+
+    #[test]
+    fn status_reports_revision_and_count() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "alpha.desktop", "Alpha", "alpha");
+        write_desktop_file(dir.path(), "beta.desktop", "Beta", "beta");
+        let index = AppIndexState::new_for_test(vec![dir.path().to_path_buf()]);
+
+        let status = index.status();
+        assert_eq!(status.revision, 1);
+        assert_eq!(status.app_count, 2);
+    }
+
+    #[test]
+    fn relevant_fs_event_accepts_desktop_files() {
+        assert!(is_relevant_app_fs_path(std::path::Path::new(
+            "/tmp/applications/t3code.desktop"
+        )));
+    }
+
+    #[test]
+    fn relevant_fs_event_ignores_non_desktop_files() {
+        assert!(!is_relevant_app_fs_path(std::path::Path::new(
+            "/tmp/applications/icon.png"
+        )));
+    }
+
+    #[test]
+    fn watcher_refreshes_after_desktop_file_created() {
+        let dir = tempdir().unwrap();
+        let index = Arc::new(AppIndexState::new_for_test(vec![dir.path().to_path_buf()]));
+        index.start_watcher().expect("watcher should start");
+
+        write_desktop_file(dir.path(), "watched.desktop", "Watched App", "watched-app");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = index.status();
+            if status.revision > 1
+                && index
+                    .search("Watched App")
+                    .iter()
+                    .any(|result| result.id == "watched")
+            {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "watcher did not refresh cache after desktop file creation"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    #[test]
+    fn watcher_refreshes_after_desktop_file_updated() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(
+            dir.path(),
+            "watched.desktop",
+            "Watched App",
+            "watched-app --old",
+        );
+
+        let index = Arc::new(AppIndexState::new_for_test(vec![dir.path().to_path_buf()]));
+        index.start_watcher().expect("watcher should start");
+
+        write_desktop_file(
+            dir.path(),
+            "watched.desktop",
+            "Watched App",
+            "watched-app --new",
+        );
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if index.resolve_exec("watched").as_deref() == Some("watched-app --new") {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "watcher did not refresh cache after desktop file update"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    #[test]
+    fn watcher_refreshes_after_desktop_file_deleted() {
+        let dir = tempdir().unwrap();
+        write_desktop_file(dir.path(), "watched.desktop", "Watched App", "watched-app");
+
+        let index = Arc::new(AppIndexState::new_for_test(vec![dir.path().to_path_buf()]));
+        index.start_watcher().expect("watcher should start");
+
+        fs::remove_file(dir.path().join("watched.desktop")).unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let status = index.status();
+            if status.revision > 1 && index.search("Watched App").is_empty() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "watcher did not refresh cache after desktop file deletion"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    #[test]
+    fn watcher_start_fails_when_no_directories_can_be_watched() {
+        let dir = tempdir().unwrap();
+        let missing_dir = dir.path().join("missing-applications");
+        let index = Arc::new(AppIndexState::new_for_test(vec![missing_dir]));
+
+        let error = index
+            .start_watcher()
+            .expect_err("watcher should fail when all source directories are missing");
+
+        assert!(error.contains("no application directories could be watched"));
+        assert!(!index.watcher_started.load(Ordering::SeqCst));
     }
 }

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -288,7 +288,7 @@ fn desktop_dirs() -> Vec<PathBuf> {
     }
 
     // Explicit Flatpak/Snap dirs ensure coverage on systems where
-    // XDG_DATA_DIRS doesn't include them. Dedup in load_desktop_entries() handles overlap.
+    // XDG_DATA_DIRS doesn't include them. Duplicate desktop IDs are deduped during loading.
     if let Some(home) = dirs::home_dir() {
         dirs.push(home.join(".local/share/flatpak/exports/share/applications"));
     }
@@ -298,11 +298,6 @@ fn desktop_dirs() -> Vec<PathBuf> {
     dirs.push(PathBuf::from("/var/lib/snapd/desktop/applications"));
 
     dirs
-}
-
-#[cfg(test)]
-fn load_desktop_entries() -> Vec<DesktopEntry> {
-    load_desktop_entries_from_dirs(&desktop_dirs())
 }
 
 fn load_desktop_entries_from_dirs(dirs: &[PathBuf]) -> Vec<DesktopEntry> {
@@ -571,6 +566,10 @@ mod tests {
             comment: "".into(),
             no_display: false,
         }
+    }
+
+    fn load_desktop_entries() -> Vec<DesktopEntry> {
+        load_desktop_entries_from_dirs(&desktop_dirs())
     }
 
     // --- strip_field_codes ---

--- a/src-tauri/src/commands/apps.rs
+++ b/src-tauri/src/commands/apps.rs
@@ -145,12 +145,15 @@ impl AppIndexState {
             return Ok(());
         }
 
-        let index = Arc::clone(self);
+        let index_weak = Arc::downgrade(self);
         let refresh_state = Arc::new(Mutex::new(WatcherRefreshState::default()));
         let refresh_state_for_callback = Arc::clone(&refresh_state);
 
         let mut watcher = match notify::recommended_watcher(
             move |result: notify::Result<notify::Event>| {
+                let Some(index) = index_weak.upgrade() else {
+                    return;
+                };
                 let event = match result {
                     Ok(event) => event,
                     Err(error) => {
@@ -224,6 +227,8 @@ impl AppIndexState {
 
         let mut watched = 0usize;
         for dir in &self.source_dirs {
+            // Note: only directories that exist at this point are watched.
+            // Directories created after startup require a manual #refresh to be scanned.
             if !dir.exists() {
                 tracing::info!(path = %dir.display(), "skipping missing application directory");
                 continue;
@@ -1128,5 +1133,25 @@ mod tests {
 
         assert!(error.contains("no application directories could be watched"));
         assert!(!index.watcher_started.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn watcher_does_not_keep_app_index_alive_after_drop() {
+        let dir = tempdir().unwrap();
+        let index = Arc::new(AppIndexState::new_for_test(vec![dir.path().to_path_buf()]));
+        let weak_index = Arc::downgrade(&index);
+
+        index.start_watcher().expect("watcher should start");
+        drop(index);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while weak_index.upgrade().is_some() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        assert!(
+            weak_index.upgrade().is_none(),
+            "watcher callback should not keep AppIndexState alive after drop"
+        );
     }
 }

--- a/src-tauri/src/commands/special.rs
+++ b/src-tauri/src/commands/special.rs
@@ -15,6 +15,17 @@ struct SpecialCommand {
 
 const COMMANDS: &[SpecialCommand] = &[
     SpecialCommand {
+        name: "refresh",
+        description: "Rescan application folders now",
+        icon: "",
+        // Sentinel exec: the backend action dispatcher intercepts `special-refresh`
+        // and refreshes the shared app cache without launching a shell command.
+        exec_command: "special-refresh",
+        input_spec: None,
+        output_mode: None,
+        output_format: None,
+    },
+    SpecialCommand {
         name: "cowork",
         description: "Open kitty in ~/cowork and run Codex",
         icon: "",
@@ -286,5 +297,13 @@ mod tests {
     #[test]
     fn resolve_special_by_id_unknown_returns_none() {
         assert!(resolve_special_by_id("special-unknown").is_none());
+    }
+
+    #[test]
+    fn refresh_command_present() {
+        let results = search_special("refresh").unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "special-refresh");
+        assert_eq!(results[0].name, "refresh");
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -712,6 +712,46 @@ pub fn reload_config() -> AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarRestore {
+        saved: Vec<(String, Option<String>)>,
+    }
+
+    impl EnvVarRestore {
+        fn capture(keys: &[&str]) -> Self {
+            Self {
+                saved: keys
+                    .iter()
+                    .map(|key| ((*key).to_string(), std::env::var(key).ok()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvVarRestore {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn with_env_test_scope<T>(keys: &[&str], f: impl FnOnce() -> T) -> T {
+        let _lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _restore = EnvVarRestore::capture(keys);
+        f()
+    }
 
     #[test]
     fn default_config_has_sane_values() {
@@ -865,92 +905,102 @@ debounce_ms = 100
 
     #[test]
     fn env_override_ollama_url() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_OLLAMA_URL", "http://custom:11434");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.ollama.url, "http://custom:11434");
-        std::env::remove_var("BURROW_OLLAMA_URL");
+        with_env_test_scope(&["BURROW_OLLAMA_URL"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_OLLAMA_URL", "http://custom:11434");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.ollama.url, "http://custom:11434");
+        });
     }
 
     #[test]
     fn env_override_embedding_model_legacy() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_OLLAMA_EMBEDDING_MODEL", "custom-model");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.models.embedding.name, "custom-model");
-        std::env::remove_var("BURROW_OLLAMA_EMBEDDING_MODEL");
+        with_env_test_scope(&["BURROW_OLLAMA_EMBEDDING_MODEL"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_OLLAMA_EMBEDDING_MODEL", "custom-model");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.models.embedding.name, "custom-model");
+        });
     }
 
     #[test]
     fn env_override_model_embedding() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_MODEL_EMBEDDING", "nomic-embed-text");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.models.embedding.name, "nomic-embed-text");
-        std::env::remove_var("BURROW_MODEL_EMBEDDING");
+        with_env_test_scope(&["BURROW_MODEL_EMBEDDING"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_MODEL_EMBEDDING", "nomic-embed-text");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.models.embedding.name, "nomic-embed-text");
+        });
     }
 
     #[test]
     fn env_override_model_chat() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_MODEL_CHAT", "llama3:8b");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.models.chat.name, "llama3:8b");
-        std::env::remove_var("BURROW_MODEL_CHAT");
+        with_env_test_scope(&["BURROW_MODEL_CHAT"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_MODEL_CHAT", "llama3:8b");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.models.chat.name, "llama3:8b");
+        });
     }
 
     #[test]
     fn env_override_model_chat_large() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_MODEL_CHAT_LARGE", "claude-opus");
-        std::env::set_var("BURROW_MODEL_CHAT_LARGE_PROVIDER", "openrouter");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.models.chat_large.name, "claude-opus");
-        assert_eq!(cfg.models.chat_large.provider, "openrouter");
-        std::env::remove_var("BURROW_MODEL_CHAT_LARGE");
-        std::env::remove_var("BURROW_MODEL_CHAT_LARGE_PROVIDER");
+        with_env_test_scope(
+            &[
+                "BURROW_MODEL_CHAT_LARGE",
+                "BURROW_MODEL_CHAT_LARGE_PROVIDER",
+            ],
+            || {
+                let mut cfg = AppConfig::default();
+                std::env::set_var("BURROW_MODEL_CHAT_LARGE", "claude-opus");
+                std::env::set_var("BURROW_MODEL_CHAT_LARGE_PROVIDER", "openrouter");
+                cfg = apply_env_overrides(cfg);
+                assert_eq!(cfg.models.chat_large.name, "claude-opus");
+                assert_eq!(cfg.models.chat_large.provider, "openrouter");
+            },
+        );
     }
 
     #[test]
     fn env_override_index_mode() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_INDEX_MODE", "custom");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.vector_search.index_mode, "custom");
-        std::env::remove_var("BURROW_INDEX_MODE");
+        with_env_test_scope(&["BURROW_INDEX_MODE"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_INDEX_MODE", "custom");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.vector_search.index_mode, "custom");
+        });
     }
 
     #[test]
     fn env_override_openrouter_api_key() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_OPENROUTER_API_KEY", "sk-burrow-test");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.openrouter.api_key, "sk-burrow-test");
-        std::env::remove_var("BURROW_OPENROUTER_API_KEY");
+        with_env_test_scope(&["BURROW_OPENROUTER_API_KEY", "OPENROUTER_API_KEY"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_OPENROUTER_API_KEY", "sk-burrow-test");
+            std::env::remove_var("OPENROUTER_API_KEY");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.openrouter.api_key, "sk-burrow-test");
+        });
     }
 
     #[test]
     fn env_override_openrouter_fallback() {
-        let saved = std::env::var("OPENROUTER_API_KEY").ok();
-        let mut cfg = AppConfig::default();
-        std::env::remove_var("BURROW_OPENROUTER_API_KEY");
-        std::env::set_var("OPENROUTER_API_KEY", "sk-fallback-test");
-        cfg = apply_env_overrides(cfg);
-        assert_eq!(cfg.openrouter.api_key, "sk-fallback-test");
-        // Restore original value
-        match saved {
-            Some(v) => std::env::set_var("OPENROUTER_API_KEY", v),
-            None => std::env::remove_var("OPENROUTER_API_KEY"),
-        }
+        with_env_test_scope(&["BURROW_OPENROUTER_API_KEY", "OPENROUTER_API_KEY"], || {
+            let mut cfg = AppConfig::default();
+            std::env::remove_var("BURROW_OPENROUTER_API_KEY");
+            std::env::set_var("OPENROUTER_API_KEY", "sk-fallback-test");
+            cfg = apply_env_overrides(cfg);
+            assert_eq!(cfg.openrouter.api_key, "sk-fallback-test");
+        });
     }
 
     #[test]
     fn env_override_vector_enabled() {
-        let mut cfg = AppConfig::default();
-        std::env::set_var("BURROW_VECTOR_SEARCH_ENABLED", "false");
-        cfg = apply_env_overrides(cfg);
-        assert!(!cfg.vector_search.enabled);
-        std::env::remove_var("BURROW_VECTOR_SEARCH_ENABLED");
+        with_env_test_scope(&["BURROW_VECTOR_SEARCH_ENABLED"], || {
+            let mut cfg = AppConfig::default();
+            std::env::set_var("BURROW_VECTOR_SEARCH_ENABLED", "false");
+            cfg = apply_env_overrides(cfg);
+            assert!(!cfg.vector_search.enabled);
+        });
     }
 
     #[test]
@@ -970,19 +1020,19 @@ debounce_ms = 100
 
     #[test]
     fn update_config_model_creates_file() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let custom_dir = tmp.path().join("burrow");
-        std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
+        with_env_test_scope(&["BURROW_CONFIG_DIR"], || {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let custom_dir = tmp.path().join("burrow");
+            std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
 
-        // Should create config file with updated model
-        update_config_model("chat_large", "openrouter", "anthropic/claude-opus").unwrap();
+            // Should create config file with updated model
+            update_config_model("chat_large", "openrouter", "anthropic/claude-opus").unwrap();
 
-        // Verify the file was created and contains the update
-        let content = std::fs::read_to_string(custom_dir.join("config.toml")).unwrap();
-        assert!(content.contains("anthropic/claude-opus"));
-        assert!(content.contains("openrouter"));
-
-        std::env::remove_var("BURROW_CONFIG_DIR");
+            // Verify the file was created and contains the update
+            let content = std::fs::read_to_string(custom_dir.join("config.toml")).unwrap();
+            assert!(content.contains("anthropic/claude-opus"));
+            assert!(content.contains("openrouter"));
+        });
     }
 
     #[test]
@@ -1105,13 +1155,14 @@ startup_timeout_secs = 10
 
     #[test]
     fn env_override_config_dir() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let custom_dir = tmp.path().join("custom-burrow");
+        with_env_test_scope(&["BURROW_CONFIG_DIR"], || {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let custom_dir = tmp.path().join("custom-burrow");
 
-        std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
-        let dir = config_dir();
-        assert_eq!(dir, custom_dir);
-        std::env::remove_var("BURROW_CONFIG_DIR");
+            std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
+            let dir = config_dir();
+            assert_eq!(dir, custom_dir);
+        });
     }
 
     // ── Config validation tests ──────────────────────────────────────
@@ -1550,22 +1601,22 @@ startup_timeout_secs = 10
 
     #[test]
     fn test_update_config_model_trims_whitespace() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let custom_dir = tmp.path().join("burrow");
-        std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
+        with_env_test_scope(&["BURROW_CONFIG_DIR"], || {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let custom_dir = tmp.path().join("burrow");
+            std::env::set_var("BURROW_CONFIG_DIR", &custom_dir);
 
-        update_config_model("chat", "ollama", "  llama3:8b  ").unwrap();
+            update_config_model("chat", "ollama", "  llama3:8b  ").unwrap();
 
-        let content = std::fs::read_to_string(custom_dir.join("config.toml")).unwrap();
-        assert!(
-            content.contains("llama3:8b"),
-            "model name should be trimmed in config file"
-        );
-        assert!(
-            !content.contains("  llama3:8b  "),
-            "untrimmed model name should not appear"
-        );
-
-        std::env::remove_var("BURROW_CONFIG_DIR");
+            let content = std::fs::read_to_string(custom_dir.join("config.toml")).unwrap();
+            assert!(
+                content.contains("llama3:8b"),
+                "model name should be trimmed in config file"
+            );
+            assert!(
+                !content.contains("  llama3:8b  "),
+                "untrimmed model name should not appear"
+            );
+        });
     }
 }

--- a/src-tauri/src/context.rs
+++ b/src-tauri/src/context.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::commands::apps::AppIndexState;
 use crate::commands::history::DbState;
 use crate::commands::vectors::VectorDbState;
 use crate::indexer::IndexerState;
@@ -12,6 +13,7 @@ pub struct AppContext {
     pub(crate) vector_db: Arc<VectorDbState>,
     pub(crate) indexer: Arc<IndexerState>,
     pub(crate) output_buffers: Arc<OutputBufferState>,
+    pub(crate) apps: Arc<AppIndexState>,
     /// Optional Tauri app handle for window operations (hide, spawn output windows).
     /// `None` in test-server / CLI mode — window ops become no-ops.
     app_handle: Option<tauri::AppHandle>,
@@ -26,6 +28,7 @@ impl AppContext {
             vector_db: Arc::new(vector_db),
             indexer: Arc::new(indexer),
             output_buffers: Arc::new(OutputBufferState::new()),
+            apps: Arc::new(AppIndexState::new()),
             app_handle: None,
         }
     }
@@ -37,12 +40,14 @@ impl AppContext {
         vector_db: Arc<VectorDbState>,
         indexer: Arc<IndexerState>,
         output_buffers: Arc<OutputBufferState>,
+        apps: Arc<AppIndexState>,
     ) -> Self {
         Self {
             db,
             vector_db,
             indexer,
             output_buffers,
+            apps,
             app_handle: None,
         }
     }
@@ -67,6 +72,10 @@ impl AppContext {
             vectors::open_vector_db().map_err(|e| format!("failed to open vector DB: {e}"))?,
         );
         Ok(Self::new(db, vector_db, IndexerState::new()))
+    }
+
+    pub fn start_app_watcher(&self) -> Result<(), String> {
+        self.apps.start_watcher()
     }
 
     /// Hide the main window if a Tauri AppHandle is available.
@@ -113,12 +122,14 @@ mod tests {
         let vector_db = Arc::new(VectorDbState::new(Connection::open_in_memory().unwrap()));
         let indexer = Arc::new(IndexerState::new());
         let output_buffers = Arc::new(OutputBufferState::new());
+        let apps = Arc::new(AppIndexState::new());
 
         let ctx = AppContext::from_arcs(
             db.clone(),
             vector_db.clone(),
             indexer.clone(),
             output_buffers.clone(),
+            apps.clone(),
         );
 
         // Arc::ptr_eq proves they share the same allocation
@@ -126,6 +137,7 @@ mod tests {
         assert!(Arc::ptr_eq(&ctx.vector_db, &vector_db));
         assert!(Arc::ptr_eq(&ctx.indexer, &indexer));
         assert!(Arc::ptr_eq(&ctx.output_buffers, &output_buffers));
+        assert!(Arc::ptr_eq(&ctx.apps, &apps));
     }
 
     #[test]

--- a/src-tauri/src/dev_server.rs
+++ b/src-tauri/src/dev_server.rs
@@ -86,6 +86,21 @@ async fn health_check(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
 }
 
+async fn app_cache_status(
+    State(ctx): State<AppState>,
+) -> Result<Json<apps::AppCacheStatus>, (StatusCode, String)> {
+    Ok(Json(ctx.apps.status()))
+}
+
+async fn refresh_app_cache(
+    State(ctx): State<AppState>,
+) -> Result<Json<apps::RefreshAppsResult>, (StatusCode, String)> {
+    ctx.apps
+        .refresh()
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
+}
+
 async fn execute_action(
     State(ctx): State<AppState>,
     Json(body): Json<ExecuteActionBody>,
@@ -138,6 +153,8 @@ pub fn build_router(ctx: Arc<AppContext>) -> Router {
         .route("/api/launch_app", post(launch_app))
         .route("/api/chat_ask", post(chat_ask))
         .route("/api/health_check", post(health_check))
+        .route("/api/app_cache_status", post(app_cache_status))
+        .route("/api/refresh_app_cache", post(refresh_app_cache))
         .route("/api/execute_action", post(execute_action))
         .route("/api/get_output", post(get_output))
         .route("/api/hide_window", post(hide_window_noop))
@@ -165,6 +182,7 @@ pub fn start(app: tauri::AppHandle) {
             managed_ctx.vector_db.clone(),
             managed_ctx.indexer.clone(),
             managed_ctx.output_buffers.clone(),
+            managed_ctx.apps.clone(),
         )
         .with_app_handle(app),
     );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,13 +69,12 @@ pub fn run() {
             }
         }))
         .setup(|app| {
-            apps::init_app_cache();
-
             // Create shared state instances once — used by both Tauri managed state and AppContext.
             let db = Arc::new(history::DbState::new(history::open_history_db()?));
             let vector_db = Arc::new(vectors::VectorDbState::new(vectors::open_vector_db()?));
             let indexer_state = Arc::new(indexer::IndexerState::new());
             let output_buffers = Arc::new(output_buffers::OutputBufferState::new());
+            let apps_state = Arc::new(apps::AppIndexState::new());
 
             // Manage individual states for Tauri commands and background indexer
             app.manage(db.clone());
@@ -85,8 +84,11 @@ pub fn run() {
             indexer::start_background_indexer(app.handle().clone());
 
             // Build AppContext sharing the same Arc references — no duplicate connections
-            let ctx = AppContext::from_arcs(db, vector_db, indexer_state, output_buffers)
+            let ctx = AppContext::from_arcs(db, vector_db, indexer_state, output_buffers, apps_state)
                 .with_app_handle(app.handle().clone());
+            if let Err(error) = ctx.start_app_watcher() {
+                tracing::warn!(error = %error, "application watcher unavailable; continuing without auto-refresh");
+            }
             app.manage(ctx);
 
             #[cfg(debug_assertions)]
@@ -113,6 +115,8 @@ pub fn run() {
             router::search_cmd,
             history::record_launch_cmd,
             apps::launch_app,
+            apps::app_cache_status_cmd,
+            apps::refresh_app_cache_cmd,
             commands::chat::chat_ask_cmd,
             commands::health::health_check_cmd,
             actions::execute_action_cmd,

--- a/src-tauri/src/router.rs
+++ b/src-tauri/src/router.rs
@@ -170,10 +170,10 @@ pub async fn search(query: String, ctx: &AppContext) -> Result<Vec<SearchResult>
             if let Some(result) = math::try_calculate(&query) {
                 Ok(vec![result])
             } else {
-                apps::search_apps(&query)
+                apps::search_apps(&query, ctx)
             }
         }
-        RouteKind::App => apps::search_apps(&query),
+        RouteKind::App => apps::search_apps(&query, ctx),
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,7 +422,7 @@ function App() {
     }
 
     // Record launch for non-ephemeral categories
-    if (!["math", "info"].includes(item.category) && item.id !== "special-refresh") {
+    if (!["math", "info"].includes(item.category)) {
       try {
         await invoke("record_launch", {
           id: item.id,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,6 +205,7 @@ function App() {
   useEffect(() => {
     let cancelled = false;
     const pageIsVisible = () => !document.hidden || navigator.webdriver;
+    appCacheRevisionRef.current = null;
 
     const syncAppCacheStatus = async (refreshResults: boolean) => {
       if (!pageIsVisible() || appCachePollInFlightRef.current) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,17 @@ interface HealthStatus {
   indexing: boolean;
 }
 
+interface AppCacheStatus {
+  revision: number;
+  app_count: number;
+}
+
+interface RefreshAppsResult {
+  changed: boolean;
+  revision: number;
+  app_count: number;
+}
+
 function healthStateFrom(status: HealthStatus): HealthState {
   if (!status.ollama || !status.vector_db) return "error";
   if (status.indexing) return "indexing";
@@ -77,11 +88,8 @@ function formatHealthNotification(status: HealthStatus): string {
 }
 
 function ResultIcon({ icon, category }: { icon: string; category: string }) {
-  const [broken, setBroken] = useState(false);
-  useEffect(() => {
-    setBroken(false);
-  }, [icon]);
-  if (!icon || broken) {
+  const [brokenIcon, setBrokenIcon] = useState<string | null>(null);
+  if (!icon || brokenIcon === icon) {
     return (
       <div className="result-icon-placeholder">
         <CategoryIcon category={category} />
@@ -93,7 +101,7 @@ function ResultIcon({ icon, category }: { icon: string; category: string }) {
       className="result-icon"
       src={icon}
       alt=""
-      onError={() => { console.warn(`[ResultIcon] failed to load icon for category="${category}"`); setBroken(true); }}
+      onError={() => { console.warn(`[ResultIcon] failed to load icon for category="${category}"`); setBrokenIcon(icon); }}
     />
   );
 }
@@ -118,6 +126,10 @@ function App() {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const queryRef = useRef(query);
+  const appCacheRevisionRef = useRef<number | null>(null);
+  const searchRequestIdRef = useRef(0);
+  const appCachePollInFlightRef = useRef(false);
+  const selectedResultIdRef = useRef<string | null>(null);
 
   // Mouse hover state machine to prevent accidental selection when window appears under cursor.
   // Phases: initial (waiting) -> tracking (measuring movement) -> enabled (hover active).
@@ -128,19 +140,34 @@ function App() {
     | { phase: "enabled" };
   const mouseStateRef = useRef<MouseHoverState>({ phase: "initial" });
 
-  const doSearch = useCallback(async (q: string) => {
+  const doSearch = useCallback(async (q: string, options?: { preserveSelection?: boolean }) => {
+    const requestId = ++searchRequestIdRef.current;
+    const selectedIdToPreserve = options?.preserveSelection ? selectedResultIdRef.current : null;
+
     try {
       const res = await invoke<SearchResult[]>("search", { query: q });
-      // Discard stale responses — query may have changed while we were waiting
-      if (queryRef.current !== q) return;
+      // Discard stale responses — query may have changed while we were waiting.
+      if (queryRef.current !== q || requestId !== searchRequestIdRef.current) return;
+
       setResults(res);
-      setSelectedIndex(0);
+      if (selectedIdToPreserve) {
+        const preservedIndex = res.findIndex((item) => item.id === selectedIdToPreserve);
+        setSelectedIndex(preservedIndex >= 0 ? preservedIndex : 0);
+      } else {
+        setSelectedIndex(0);
+      }
     } catch (e) {
       console.error("Search failed:", e);
-      if (queryRef.current === q) {
+      if (queryRef.current === q && requestId === searchRequestIdRef.current) {
         setResults([]);
       }
     }
+  }, []);
+
+  const showNotification = useCallback((message: string, timeout = 6000) => {
+    setNotification(message);
+    if (notificationTimer.current) clearTimeout(notificationTimer.current);
+    notificationTimer.current = setTimeout(() => setNotification(""), timeout);
   }, []);
 
   useEffect(() => {
@@ -171,14 +198,72 @@ function App() {
     queryRef.current = query;
   }, [query]);
 
+  useEffect(() => {
+    selectedResultIdRef.current = results[selectedIndex]?.id ?? null;
+  }, [results, selectedIndex]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const pageIsVisible = () => !document.hidden || navigator.webdriver;
+
+    const syncAppCacheStatus = async (refreshResults: boolean) => {
+      if (!pageIsVisible() || appCachePollInFlightRef.current) {
+        return;
+      }
+
+      appCachePollInFlightRef.current = true;
+      try {
+        const status = await invoke<AppCacheStatus>("app_cache_status");
+        if (cancelled) return;
+
+        const previousRevision = appCacheRevisionRef.current;
+        appCacheRevisionRef.current = status.revision;
+
+        if (
+          !secondaryMode.active &&
+          (
+            previousRevision === null ||
+            (refreshResults && previousRevision !== status.revision)
+          )
+        ) {
+          await doSearch(queryRef.current, { preserveSelection: refreshResults });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.error("App cache status failed:", err);
+        }
+      } finally {
+        appCachePollInFlightRef.current = false;
+      }
+    };
+
+    void syncAppCacheStatus(false);
+    const interval = setInterval(() => {
+      if (pageIsVisible()) {
+        void syncAppCacheStatus(true);
+      }
+    }, 1000);
+
+    const onVisibilityChange = () => {
+      if (pageIsVisible()) {
+        void syncAppCacheStatus(true);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [doSearch, secondaryMode.active]);
+
   // Listen for vault-load-result events from 1Password load action
   useEffect(() => {
     const unlisten = listen<{ ok: boolean; message: string }>("vault-load-result", (event) => {
       const { ok, message } = event.payload;
       const prefix = ok ? "✓ " : "✗ ";
-      setNotification(prefix + message);
-      if (notificationTimer.current) clearTimeout(notificationTimer.current);
-      notificationTimer.current = setTimeout(() => setNotification(""), ok ? 4000 : 8000);
+      showNotification(prefix + message, ok ? 4000 : 8000);
       // Refresh search to show loaded items (use ref to get current query without re-subscribing)
       if (ok) {
         doSearch(queryRef.current);
@@ -187,7 +272,7 @@ function App() {
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [doSearch]);
+  }, [doSearch, showNotification]);
 
   // Clear input when window is hidden
   useEffect(() => {
@@ -318,8 +403,26 @@ function App() {
       return;
     }
 
+    if (item.id === "special-refresh") {
+      try {
+        const refreshed = await invoke<RefreshAppsResult>("refresh_app_cache");
+        appCacheRevisionRef.current = refreshed.revision;
+        showNotification(
+          refreshed.changed
+            ? `Apps refreshed (${refreshed.app_count} apps)`
+            : "App list already up to date"
+        );
+        await doSearch(queryRef.current);
+      } catch (err) {
+        console.error("Refresh apps failed:", err);
+        const errMsg = err instanceof Error ? err.message : String(err);
+        showNotification(`✗ Refresh failed: ${errMsg}`);
+      }
+      return;
+    }
+
     // Record launch for non-ephemeral categories
-    if (!["math", "info"].includes(item.category)) {
+    if (!["math", "info"].includes(item.category) && item.id !== "special-refresh") {
       try {
         await invoke("record_launch", {
           id: item.id,
@@ -343,11 +446,9 @@ function App() {
     } catch (err) {
       console.error("Execute action failed:", err);
       const errMsg = err instanceof Error ? err.message : String(err);
-      setNotification(`✗ Action failed: ${errMsg}`);
-      if (notificationTimer.current) clearTimeout(notificationTimer.current);
-      notificationTimer.current = setTimeout(() => setNotification(""), 6000);
+      showNotification(`✗ Action failed: ${errMsg}`);
     }
-  }, [results, selectedIndex, query, secondaryMode, secondaryInput]);
+  }, [results, selectedIndex, query, secondaryMode, secondaryInput, doSearch, showNotification]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -410,30 +511,36 @@ function App() {
           spellCheck={false}
         />
         {!secondaryMode.active && (
-          <span
+          <button
+            type="button"
             className={`health-indicator ${HEALTH_CLASS[health]}`}
             title={HEALTH_TITLE[health]}
+            aria-label="Show system health details"
             onClick={async () => {
               try {
                 const status = await invoke<HealthStatus>("health_check");
                 setHealth(healthStateFrom(status));
-                setNotification(formatHealthNotification(status));
+                showNotification(formatHealthNotification(status));
               } catch (err) {
                 setHealth("error");
                 const errMsg = err instanceof Error ? err.message : String(err);
-                setNotification(`Health check failed: ${errMsg}`);
-              } finally {
-                if (notificationTimer.current) clearTimeout(notificationTimer.current);
-                notificationTimer.current = setTimeout(() => setNotification(""), 6000);
+                showNotification(`Health check failed: ${errMsg}`);
               }
             }}
           >
             {HEALTH_ICON[health]}
-          </span>
+          </button>
         )}
       </div>
       {notification && (
-        <div className="notification">{notification}</div>
+        <div
+          className="notification"
+          role={/^(✗|Health check failed)/.test(notification) ? "alert" : "status"}
+          aria-live={/^(✗|Health check failed)/.test(notification) ? "assertive" : "polite"}
+          aria-atomic="true"
+        >
+          {notification}
+        </div>
       )}
       {chatLoading && (
         <div className="chat-answer chat-loading">Thinking...</div>

--- a/src/mock-tauri.ts
+++ b/src/mock-tauri.ts
@@ -8,7 +8,15 @@ const DEV_API = "http://127.0.0.1:3001/api";
 // Tauri registers _cmd-suffixed handlers to avoid collisions with core functions.
 // Commands without a _cmd suffix (hide_window, launch_app) pass through via ?? fallback.
 // SYNC: keep in sync with generate_handler![] in src-tauri/src/lib.rs
-type TauriMappedCmd = "search" | "health_check" | "chat_ask" | "record_launch" | "execute_action" | "get_output";
+type TauriMappedCmd =
+  | "search"
+  | "health_check"
+  | "chat_ask"
+  | "record_launch"
+  | "execute_action"
+  | "get_output"
+  | "app_cache_status"
+  | "refresh_app_cache";
 const TAURI_CMD: Record<TauriMappedCmd, `${TauriMappedCmd}_cmd`> = {
   search: "search_cmd",
   health_check: "health_check_cmd",
@@ -16,6 +24,8 @@ const TAURI_CMD: Record<TauriMappedCmd, `${TauriMappedCmd}_cmd`> = {
   record_launch: "record_launch_cmd",
   execute_action: "execute_action_cmd",
   get_output: "get_output_cmd",
+  app_cache_status: "app_cache_status_cmd",
+  refresh_app_cache: "refresh_app_cache_cmd",
 };
 
 export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,6 +43,15 @@ body {
   font-size: 18px;
   cursor: pointer;
   user-select: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  line-height: 1;
+}
+
+.health-indicator:focus-visible {
+  outline: 2px solid #7aa2f7;
+  outline-offset: 4px;
 }
 
 .health-ok {


### PR DESCRIPTION
## Summary
- replace the startup-only desktop app cache with shared live app index state on `AppContext`
- auto-refresh the backend cache from `.desktop` directory watcher changes and add manual `#refresh`
- poll app-cache revision in the frontend so visible results update without restarting
- harden the E2E harness and add refresh coverage for auto and manual app discovery

## Verification
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- `pnpm build`
- `npx playwright test`
- `npx -y react-doctor@latest . --verbose --diff`
